### PR TITLE
Add working OpenAQ REST helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+data/
+plots/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-# Python-Projekt
+# Luftqualitätsanalyse mit OpenAQ
+
+Dieses Projekt demonstriert einen kompletten Workflow für den Abruf, die Verarbeitung und Analyse von Luftqualitätsdaten über die [OpenAQ API](https://docs.openaq.org/).
+
+## Umsetzungsplan
+
+1. **API-Anbindung**
+   - Datenabruf über die offizielle Bibliothek `openaq` oder alternativ direkt per `requests`.
+   - Unterstützung für Parameter wie Stadt, Land, Messgröße und Datumsbereich.
+   - Für die Version 3 der API wird ein gültiger API-Key benötigt (Umgebungsvariable `OPENAQ_API_KEY`).
+   - Speicherung der Rohdaten als CSV unter `data/raw_measurements.csv`.
+2. **Datenvorverarbeitung**
+   - Laden der Rohdaten in ein Pandas-DataFrame.
+   - Konvertierung der Datumsfelder und Bereinigung fehlender Werte.
+   - Aggregation auf Tages- oder Monatsbasis.
+   - Ergebnis wird als `data/processed_data.csv` gespeichert.
+3. **Datenanalyse**
+   - Berechnung von Mittelwert, Median, Minimum, Maximum und Standardabweichung für ausgewählte Messgrößen.
+   - Ausgabe der Statistiken auf der Konsole und als CSV-Datei.
+4. **Datenvisualisierung**
+   - Liniendiagramm zur zeitlichen Entwicklung eines Messwerts.
+   - Balkendiagramm für den Vergleich verschiedener Orte.
+   - Boxplot zur Darstellung der Verteilung.
+   - Interaktive Karte der Messstationen mit `folium`.
+   - Grafiken werden unter `plots/` als PNG gespeichert.
+5. **Export und Nutzung**
+   - Alle erzeugten CSV-Dateien und Grafiken können direkt weiterverarbeitet werden.
+   - Einfache Ausführung über `python main.py` mit optionalen Argumenten.
+
+## Installation
+
+1. Abhängigkeiten installieren:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Skript ausführen (Beispiel für Berlin und PM2.5):
+   ```bash
+   export OPENAQ_API_KEY=<dein_api_key>
+   # Standardmäßig wird der Python-Client genutzt
+   python main.py --city Berlin --parameter pm25 --start 2023-01-01 --end 2023-01-31
+
+   # Alternativ kann die REST-Schnittstelle verwendet werden
+   python main.py --rest --city Berlin --parameter pm25 --start 2023-01-01 --end 2023-01-31
+   ```
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,60 @@
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from src.openaq_api import fetch_measurements, fetch_measurements_rest, save_dataframe
+from src.analysis_utils import preprocess, aggregate_daily, compute_statistics, plot_time_series, plot_box, create_map
+import os
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Analyse von OpenAQ-Daten")
+    parser.add_argument("--city", type=str, help="Stadtname", required=False)
+    parser.add_argument("--country", type=str, help="Ländercode", required=False)
+    parser.add_argument("--parameter", type=str, default="pm25",
+                        help="Messgröße, z.B. pm25")
+    parser.add_argument("--start", type=str, help="Startdatum YYYY-MM-DD")
+    parser.add_argument("--end", type=str, help="Enddatum YYYY-MM-DD")
+    parser.add_argument("--max-pages", type=int, default=5,
+                        help="Maximale Anzahl API-Seiten")
+    parser.add_argument("--rest", action="store_true",
+                        help="Statt des Python-Clients die REST-Schnittstelle verwenden")
+    parser.add_argument("--api-key", type=str,
+                        default=os.getenv("OPENAQ_API_KEY"),
+                        help="API-Schlüssel für OpenAQ")
+    args = parser.parse_args()
+
+    raw_path = Path("data/raw_measurements.csv")
+    processed_path = Path("data/processed_data.csv")
+    stats_path = Path("data/statistics.csv")
+
+    raw_path.parent.mkdir(parents=True, exist_ok=True)
+    Path("plots").mkdir(parents=True, exist_ok=True)
+
+    fetch_func = fetch_measurements_rest if args.rest else fetch_measurements
+    df = fetch_func(city=args.city,
+                    country=args.country,
+                    parameter=args.parameter,
+                    date_from=args.start,
+                    date_to=args.end,
+                    max_pages=args.max_pages,
+                    api_key=args.api_key)
+    save_dataframe(df, raw_path)
+
+    df = preprocess(df)
+    daily = aggregate_daily(df)
+    daily.to_csv(processed_path, index=False)
+
+    stats = compute_statistics(df["value"])
+    stats.to_frame(name="value").to_csv(stats_path)
+    print(stats)
+
+    plot_time_series(daily, "plots/time_series.png")
+    plot_box(df, "plots/boxplot.png")
+    create_map(df.head(100), "plots/map.html")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+requests
+pandas
+numpy
+matplotlib
+seaborn
+folium
+openaq

--- a/src/analysis_utils.py
+++ b/src/analysis_utils.py
@@ -1,0 +1,72 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+import folium
+from typing import Tuple
+
+
+def preprocess(df: pd.DataFrame) -> pd.DataFrame:
+    """Clean and convert date columns."""
+    if 'date' in df.columns and isinstance(df.loc[0, 'date'], dict):
+        df['datetime'] = pd.to_datetime(df['date'].apply(lambda x: x.get('utc')))
+    elif 'date.utc' in df.columns:
+        df['datetime'] = pd.to_datetime(df['date.utc'])
+    else:
+        df['datetime'] = pd.to_datetime(df['datetime'])
+    df = df.dropna(subset=['value'])
+    return df
+
+
+def aggregate_daily(df: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate measurements by day."""
+    df = df.set_index('datetime')
+    daily = df['value'].resample('D').mean().reset_index()
+    daily.rename(columns={'value': 'mean_value'}, inplace=True)
+    return daily
+
+
+def compute_statistics(series: pd.Series) -> pd.Series:
+    return pd.Series({
+        'mean': series.mean(),
+        'median': series.median(),
+        'min': series.min(),
+        'max': series.max(),
+        'std': series.std(),
+    })
+
+
+def plot_time_series(daily: pd.DataFrame, output: str) -> None:
+    plt.figure(figsize=(10, 5))
+    sns.lineplot(data=daily, x='datetime', y='mean_value')
+    plt.title('Tägliche Durchschnittswerte')
+    plt.xlabel('Datum')
+    plt.ylabel('Messwert')
+    plt.tight_layout()
+    plt.savefig(output)
+    plt.close()
+
+
+def plot_box(df: pd.DataFrame, output: str) -> None:
+    plt.figure(figsize=(6, 4))
+    sns.boxplot(x=df['value'])
+    plt.title('Verteilung der Messwerte')
+    plt.xlabel('Messwert')
+    plt.tight_layout()
+    plt.savefig(output)
+    plt.close()
+
+
+def create_map(df: pd.DataFrame, output: str) -> None:
+    m = folium.Map(location=[df['coordinates.latitude'].mean(),
+                             df['coordinates.longitude'].mean()],
+                   zoom_start=5)
+    for _, row in df.iterrows():
+        folium.CircleMarker(
+            location=[row['coordinates.latitude'], row['coordinates.longitude']],
+            radius=4,
+            popup=f"{row['location']} {row['value']} {row['unit']}",
+            color='blue',
+            fill=True,
+        ).add_to(m)
+    m.save(output)
+

--- a/src/openaq_api.py
+++ b/src/openaq_api.py
@@ -1,0 +1,161 @@
+"""Helper functions for accessing the OpenAQ API."""
+
+from datetime import datetime
+from typing import Optional, List
+
+import pandas as pd
+import requests
+from openaq import OpenAQ
+
+BASE_URL = "https://api.openaq.org/v3"
+
+
+def fetch_measurements_rest(city: Optional[str] = None,
+                            country: Optional[str] = None,
+                            parameter: str = "pm25",
+                            date_from: Optional[str] = None,
+                            date_to: Optional[str] = None,
+                            limit: int = 100,
+                            max_pages: int = 5,
+                            api_key: Optional[str] = None) -> pd.DataFrame:
+    """Fetch measurements from the REST API and return as DataFrame.
+
+    Parameters
+    ----------
+    city : optional str
+        City to filter measurements.
+    country : optional str
+        Country code to filter measurements.
+    parameter : str
+        Pollutant parameter (e.g., pm25, pm10, no2).
+    date_from : optional str
+        Start date in YYYY-MM-DD format.
+    date_to : optional str
+        End date in YYYY-MM-DD format.
+    limit : int
+        Number of records per page.
+    max_pages : int
+        Maximum number of pages to fetch.
+    """
+    headers = {"X-API-Key": api_key} if api_key else None
+
+    # First fetch locations
+    loc_params = {"limit": 1}
+    if country:
+        loc_params["iso"] = country
+    loc_resp = requests.get(f"{BASE_URL}/locations", params=loc_params, headers=headers, timeout=30)
+    loc_resp.raise_for_status()
+    locations = [
+        loc for loc in loc_resp.json().get("results", [])
+        if city is None or (loc.get("locality") and loc["locality"].lower() == city.lower())
+    ]
+
+    records: List[dict] = []
+    for loc in locations:
+        sens_resp = requests.get(f"{BASE_URL}/locations/{loc['id']}/sensors", headers=headers, timeout=30)
+        sens_resp.raise_for_status()
+        sensors = [s for s in sens_resp.json().get("results", []) if s.get("parameter", {}).get("name") == parameter]
+        for sensor in sensors:
+            page = 1
+            while page <= max_pages:
+                params = {
+                    "page": page,
+                    "limit": limit,
+                }
+                if date_from:
+                    params["date_from"] = date_from
+                if date_to:
+                    params["date_to"] = date_to
+                resp = requests.get(
+                    f"{BASE_URL}/sensors/{sensor['id']}/measurements",
+                    params=params,
+                    headers=headers,
+                    timeout=30,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                for m in data.get("results", []):
+                    records.append({
+                        "location": loc.get("name"),
+                        "city": loc.get("locality"),
+                        "sensor_id": sensor["id"],
+                        "value": m.get("value"),
+                        "unit": sensor["parameter"]["units"],
+                        "datetime": m["period"]["datetimeFrom"]["utc"],
+                        "coordinates.latitude": (m.get("coordinates", {}).get("latitude")
+                                                 if m.get("coordinates") else loc.get("coordinates", {}).get("latitude")),
+                        "coordinates.longitude": (m.get("coordinates", {}).get("longitude")
+                                                  if m.get("coordinates") else loc.get("coordinates", {}).get("longitude")),
+                    })
+                if len(data.get("results", [])) < limit:
+                    break
+                page += 1
+    df = pd.DataFrame.from_records(records)
+    return df
+
+
+def save_dataframe(df: pd.DataFrame, path: str) -> None:
+    """Save DataFrame as CSV."""
+    df.to_csv(path, index=False)
+
+
+def fetch_measurements(city: Optional[str] = None,
+                       country: Optional[str] = None,
+                       parameter: str = "pm25",
+                       date_from: Optional[str] = None,
+                       date_to: Optional[str] = None,
+                       limit: int = 100,
+                       max_pages: int = 5,
+                       api_key: Optional[str] = None) -> pd.DataFrame:
+    """Fetch measurements using the official OpenAQ Python client.
+
+    This helper queries locations matching the given filters, retrieves
+    sensors for those locations and then fetches measurement data.
+    """
+
+    client = OpenAQ(api_key=api_key)
+
+    param_map = {p.name: p.id for p in client.parameters.list().results}
+    param_id = param_map.get(parameter)
+    if param_id is None:
+        raise ValueError(f"Unknown parameter '{parameter}'")
+
+    loc_resp = client.locations.list(iso=country, limit=1)
+    locations = [
+        loc for loc in loc_resp.results
+        if city is None or (hasattr(loc, "locality") and loc.locality and loc.locality.lower() == city.lower())
+    ]
+
+    records: List[dict] = []
+    for loc in locations:
+        sensors_resp = client.locations.sensors(loc.id)
+        sensors = [s for s in sensors_resp.results if s.parameter["id"] == param_id]
+        for sensor in sensors:
+            page = 1
+            while page <= max_pages:
+                meas_resp = client.measurements.list(
+                    sensor.id,
+                    datetime_from=date_from,
+                    datetime_to=date_to,
+                    page=page,
+                    limit=limit,
+                )
+                for m in meas_resp.results:
+                    records.append({
+                        "location": loc.name,
+                        "city": getattr(loc, "locality", None),
+                        "sensor_id": sensor.id,
+                        "value": m.value,
+                        "unit": sensor.parameter["units"],
+                        "datetime": m.period.datetime_from.utc,
+                        "coordinates.latitude": (m.coordinates.latitude
+                                                 if m.coordinates else loc.coordinates.latitude),
+                        "coordinates.longitude": (m.coordinates.longitude
+                                                  if m.coordinates else loc.coordinates.longitude),
+                    })
+                if len(meas_resp.results) < limit:
+                    break
+                page += 1
+
+    return pd.DataFrame.from_records(records)
+


### PR DESCRIPTION
## Summary
- create output folders automatically
- overhaul REST client to use location and sensor endpoints
- default to first location to avoid rate limits
- fix country filter parameter

## Testing
- `pip install -q -r requirements.txt`
- `python main.py --help | head -n 20`
- `python main.py --rest --country DE --parameter pm25 --start 2023-01-01 --end 2023-01-02 --max-pages 1 | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6870f02ab1f0832489d4dae83140dbfa